### PR TITLE
New feature - initialize and generate test using arguments

### DIFF
--- a/benchmarks/Creator-Tool/create_helper_shell.py
+++ b/benchmarks/Creator-Tool/create_helper_shell.py
@@ -2,10 +2,11 @@
 """"
 Project Name : Cavium_BMTool
 File Name: create_helper_shell.sh  
-Author: rgadgil 
+Author: rgadgil, blei
 File Created: 09/26/2016   13:04
 Details:
 """
+import argparse
 import configparser
 import os
 
@@ -25,6 +26,15 @@ def inplace_change(filename, old_string, new_string):
         print('Changing "{old_string}" to "{new_string}" in {filename}'.format(**locals()))
         s = s.replace(old_string, new_string)
         f.write(s)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Creates benchmark directories and generates skeleton code.")
+    parser.add_argument('testname', help='Name of test to initialize or generate files for')
+    parser.add_argument('-i', '--initialize', action='store_true', help='Initializes test directories (required once)', required=False)
+
+    args = parser.parse_args()
+    return args
 
 
 def read_config_file(this_test):
@@ -76,18 +86,42 @@ def read_config_file(this_test):
                                "${NORM}. Default is ${BOLD}" + sub_config[items]['default'] + "${NORM}.\"" + "\n"
             inplace_change(change_file, "{VARS_PYTHON_HELP}", help_string)
             inplace_change(change_file, "${TEST_TYPE}", this_test)
+            # Move generated files to the correct directories
+            if os.path.isfile("./{0}_client.sh".format(this_test)):
+                os.rename("./{0}_client.sh".format(this_test), "../{0}/scripts/client/{0}_client.sh".format(this_test))
+            if os.path.isfile("./{0}_server.sh".format(this_test)):
+                os.rename("./{0}_server.sh".format(this_test), "../{0}/scripts/server/{0}_server.sh".format(this_test))
     else:
         print("../../" + config[this_test]['Helpfile'])
         print("File does not exist")
 
-
-# read_config_file("sysbench-mysql")
-# read_config_file("Nginx")
-# read_config_file("memcached")
-# read_config_file("lmbench-mem")
-# read_config_file("lmbench-stream")
-# read_config_file("sysbench-fio")
-# read_config_file("iperf")
-# read_config_file("coremark")
-# read_config_file("specint")
-read_config_file("multichase")
+args_list = get_args()
+test = args_list.testname
+if args_list.initialize:
+    print("\nCreating directories and empty .config file for {0}...".format(test), end='')
+    os.makedirs('../{0}/config'.format(test), exist_ok=True)
+    os.makedirs('../{0}/scripts/client'.format(test), exist_ok=True)
+    os.makedirs('../{0}/scripts/server'.format(test), exist_ok=True)
+    open('../{0}/config/{0}.config'.format(test), 'a').close()
+    print("Complete.\n")
+    print("Adding {0} to ListofTests.txt and ListofTests.config...".format(test))
+    with open("../../config/ListofTests.txt", "a") as listfile:
+        listfile.write((',' + test).rstrip('\n'))
+    with open("../../config/ListofTests.config", "a") as listfile:
+        helpstring = input("Helpstring (ENTER for default): ")
+        if not helpstring:
+            helpstring = "Run the {0} benchmark".format(test)
+        helpfile = "/benchmarks/{0}/config/{0}.config".format(test)
+        server = input("Server will run (ENTER for default): ")
+        client = input("Client will run (ENTER for default): ")
+        if not server:
+            server = test
+        if not client:
+            client = test
+        listfile.write("[{0}]\nHelpstring : {1}\nHelpfile : {2}\n".format(test, helpstring, helpfile))
+        listfile.write("Server : {0}\nClient : {1}\n\n".format(server, client))
+    print("Complete.")
+    print("\nAdd useful flags to {0}.config, then rerun this script.".format(test))
+else:
+    print("Generating skeleton files for {0}.".format(test))
+    read_config_file(test)


### PR DESCRIPTION
**create_helper_shell.py** now requires a **test name** as a parameter. It will generate .sh files for that test, using an existing config file.

If the config file does not exist, you can run the script with the **-i** flag to initialize the test's directories + config file; you can then edit the config file and rerun the script.